### PR TITLE
重构测试

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,10 @@
 import pytest
 from six.moves.urllib_parse import urlparse
 
+from .prepare import default_appname, default_git, default_sha, make_specs_text
 from citadel.app import create_app
 from citadel.ext import db, rds
+from citadel.models import App, Release
 
 
 @pytest.fixture
@@ -39,6 +41,8 @@ def test_db(request, app):
         raise Exception('Need to run test on localhost or in container')
 
     db.create_all()
+    app = App.get_or_create(default_appname, git=default_git)
+    Release.create(app, default_sha, make_specs_text())
 
     def teardown():
         db.session.remove()

--- a/tests/prepare.py
+++ b/tests/prepare.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+import random
+import string
+import yaml
+from telnetlib import Telnet
+
+from citadel.config import ZONE_CONFIG
+from citadel.models.specs import Specs
+
+
+core_online = False
+try:
+    for zone in ZONE_CONFIG.values():
+        ip, port = zone['CORE_URL'].split(':')
+        Telnet(ip, port).close()
+        core_online = True
+except ConnectionRefusedError:
+    core_online = False
+
+
+default_appname = 'test-app'
+default_sha = '651fe0a'
+default_port = ['8000']
+default_git = 'git@github.com:projecteru2/citadel.git'
+artifact_content = ''.join(random.choices(string.ascii_uppercase + string.digits, k=8))
+artifact_filename = '{}-data.txt'.format(default_appname)
+default_entrypoints = {
+    'web': {
+        'cmd': 'python -m http.server',
+        'ports': default_port,
+    },
+    'test-working-dir': {
+        'cmd': 'echo pass',
+        'working_dir': '/tmp',
+    },
+}
+default_builds = {
+    'make-artifacts': {
+        'base': 'python:latest',
+        'commands': ['echo {} > {}'.format(artifact_content, artifact_filename)],
+        'cache': {artifact_filename: '/home/{}/{}'.format(default_appname, artifact_filename)},
+    },
+    'pack': {
+        'base': 'python:latest',
+        'commands': ['mkdir -p /etc/whatever'],
+    },
+}
+
+
+def make_specs_text(appname=default_appname,
+                    entrypoints=default_entrypoints,
+                    stages=list(default_builds.keys()),
+                    container_user=None,
+                    builds=default_builds,
+                    volumes=['/tmp:/home/{}/tmp'.format(default_appname)],
+                    base='hub.ricebook.net',
+                    subscribers='#platform',
+                    permitted_users=['liuyifu'],
+                    crontab=[],
+                    **kwargs):
+    specs_dict = locals()
+    kwargs = specs_dict.pop('kwargs')
+    for k, v in kwargs.items():
+        specs_dict[k] = v
+
+    specs_dict = {k: v for k, v in specs_dict.items() if v}
+    specs_string = yaml.dump(specs_dict)
+    return specs_string
+
+
+def make_specs(appname=default_appname,
+               entrypoints=default_entrypoints,
+               stages=list(default_builds.keys()),
+               container_user=None,
+               builds=default_builds,
+               volumes=['/tmp:/home/{}/tmp'.format(default_appname)],
+               base='hub.ricebook.net',
+               subscribers='#platform',
+               permitted_users=['liuyifu'],
+               crontab=[],
+               **kwargs):
+    specs_dict = locals()
+    kwargs = specs_dict.pop('kwargs')
+    for k, v in kwargs.items():
+        specs_dict[k] = v
+
+    specs_dict = {k: v for k, v in specs_dict.items() if v}
+    specs_string = yaml.dump(specs_dict)
+    Specs.validate(specs_string)
+    return Specs.from_string(specs_string)

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,23 +1,13 @@
 import pytest
 import requests
 from humanfriendly import parse_size
-from telnetlib import Telnet
 from time import sleep
 
-from .test_specs import make_specs, default_appname, default_sha, default_port, artifact_filename, artifact_content
-from citadel.config import ZONE_CONFIG, BUILD_ZONE
+from .prepare import core_online, make_specs, default_appname, default_sha, default_port, artifact_filename, artifact_content
+from citadel.config import BUILD_ZONE
 from citadel.rpc import core_pb2 as pb
 from citadel.rpc.client import get_core
 
-
-core_online = False
-try:
-    for zone in ZONE_CONFIG.values():
-        ip, port = zone['CORE_URL'].split(':')
-        Telnet(ip, port).close()
-        core_online = True
-except ConnectionRefusedError:
-    core_online = False
 
 pytestmark = pytest.mark.skipif(not core_online, reason='one or more eru-core is offline, skip core-related tests')
 

--- a/tests/test_specs.py
+++ b/tests/test_specs.py
@@ -1,82 +1,8 @@
 # -*- coding: utf-8 -*-
-import string
-import random
 import pytest
-import yaml
 from marshmallow import ValidationError
 
-from citadel.models.specs import Specs
-
-
-default_appname = 'test-app'
-default_sha = '651fe0a'
-default_port = ['8000']
-artifact_content = ''.join(random.choices(string.ascii_uppercase + string.digits, k=8))
-artifact_filename = '{}-data.txt'.format(default_appname)
-default_entrypoints = {
-    'web': {
-        'cmd': 'python -m http.server',
-        'ports': default_port,
-    },
-    'test-working-dir': {
-        'cmd': 'echo pass',
-        'working_dir': '/tmp',
-    },
-}
-default_builds = {
-    'make-artifacts': {
-        'base': 'python:latest',
-        'commands': ['echo {} > {}'.format(artifact_content, artifact_filename)],
-        'cache': {artifact_filename: '/home/{}/{}'.format(default_appname, artifact_filename)},
-    },
-    'pack': {
-        'base': 'python:latest',
-        'commands': ['mkdir -p /etc/whatever'],
-    },
-}
-
-
-def make_specs_text(appname=default_appname,
-                    entrypoints=default_entrypoints,
-                    stages=list(default_builds.keys()),
-                    container_user=None,
-                    builds=default_builds,
-                    volumes=['/tmp:/home/{}/tmp'.format(default_appname)],
-                    base='hub.ricebook.net',
-                    subscribers='#platform',
-                    permitted_users=['liuyifu'],
-                    crontab=[],
-                    **kwargs):
-    specs_dict = locals()
-    kwargs = specs_dict.pop('kwargs')
-    for k, v in kwargs.items():
-        specs_dict[k] = v
-
-    specs_dict = {k: v for k, v in specs_dict.items() if v}
-    specs_string = yaml.dump(specs_dict)
-    return specs_string
-
-
-def make_specs(appname=default_appname,
-               entrypoints=default_entrypoints,
-               stages=list(default_builds.keys()),
-               container_user=None,
-               builds=default_builds,
-               volumes=['/tmp:/home/{}/tmp'.format(default_appname)],
-               base='hub.ricebook.net',
-               subscribers='#platform',
-               permitted_users=['liuyifu'],
-               crontab=[],
-               **kwargs):
-    specs_dict = locals()
-    kwargs = specs_dict.pop('kwargs')
-    for k, v in kwargs.items():
-        specs_dict[k] = v
-
-    specs_dict = {k: v for k, v in specs_dict.items() if v}
-    specs_string = yaml.dump(specs_dict)
-    Specs.validate(specs_string)
-    return Specs.from_string(specs_string)
+from .prepare import make_specs, default_appname, default_entrypoints, default_port
 
 
 def test_extra_fields():


### PR DESCRIPTION
* 在 ~conftest~ prepare.py 里检查 core 是否在线, 有的话, 就可以跑集成测试, 没有的话就只能跑 citadel 自己的单元测试了
* 把生成 specs 的工具函数也扔到 ~conftest~ prepare.py 里了, 让别的测试在使用的时候导入方便一些
* 在 db 这个 fixture 里, 生成默认的 app 和 release, 因为很多 api 的调用需要事先创建好 app 或者 release

这个 PR 会决定之后写测试的形态, 需要 @tonicbupt 进行 review 以及决定是否合并