### PR TITLE
re-write build API using websocket

### DIFF
--- a/bin/run-worker
+++ b/bin/run-worker
@@ -1,0 +1,2 @@
+#!/bin/sh
+SQLALCHEMY_DATABASE_URI="mysql+pymysql://root:kix00iJBqFF@localhost:3306/citadeltest" REDIS_URL="redis://localhost:6379/1" celery -A citadel.app:celery worker --loglevel DEBUG -Q citadel

--- a/citadel/api/action.py
+++ b/citadel/api/action.py
@@ -1,76 +1,35 @@
 # -*- coding: utf-8 -*-
-from flask import abort, request, g, jsonify, Response
-from itertools import chain
-from webargs.flaskparser import use_args
 
-from citadel.libs.datastructure import AbortDict
-from citadel.libs.validation import DeploySchema
+'''
+This module contains all websocket APIs, first thing received will be a json
+payload, and then the server will return everything as websocket frames
+'''
+import json
+from json.decoder import JSONDecodeError
+
+from citadel.libs.utils import logger
+from citadel.libs.validation import BuildArgsSchema
 from citadel.libs.view import create_api_blueprint
-from citadel.models.app import Release
-from citadel.tasks import (ActionError, create_container, remove_container,
-                           upgrade_container_dispatch,
-                           celery_task_stream_response,
-                           celery_task_stream_traceback, build_image)
+from citadel.tasks import celery_task_stream_response, build_image
 
 
-# 把action都挂在/api/:version/下, 不再加前缀
-# 也不需要他帮忙自动转JSON了
-bp = create_api_blueprint('action', __name__, jsonize=False)
+ws = create_api_blueprint('action', __name__, url_prefix='action', jsonize=False, handle_http_error=False)
+build_args_schema = BuildArgsSchema()
 
 
-@bp.route('/build', methods=['POST'])
-def build():
-    data = AbortDict(request.get_json())
+@ws.route('/build')
+def build(socket):
+    message = socket.receive()
+    try:
+        payload = build_args_schema.loads(message)
+    except JSONDecodeError as e:
+        socket.close(message=json.dumps(e))
 
-    # TODO 参数需要类型校验
-    appname = data['appname']
-    sha = data['sha']
-    uid = data.get('uid', '')
+    if payload.errors:
+        socket.close(message=json.dumps(payload.errors))
 
-    async_result = build_image.delay(appname, sha, uid)
-    task_id = async_result.task_id
-    messages = chain(celery_task_stream_response(task_id), celery_task_stream_traceback(task_id))
-    return Response(messages, mimetype='application/json')
-
-
-@bp.route('/deploy', methods=['POST'])
-@use_args(DeploySchema())
-def deploy(args):
-    appname = args['appname']
-    sha = args['sha']
-    release = Release.get_by_app_and_sha(appname, sha)
-    if not release:
-        abort(404, 'Release {} for {} not found'.format(sha, appname))
-
-    combo_name = args['combo_name']
-    app = release.app
-    combo = app.get_combo(combo_name)
-    if not combo:
-        abort(404, 'Combo {} for {} not found'.format(combo_name, appname))
-
-    async_result = create_container.delay(zone=g.zone, user_id=g.user.id, **args)
-    return Response(celery_task_stream_response(async_result.task_id), mimetype='application/json')
-
-
-@bp.route('/remove', methods=['POST'])
-def remove():
-    data = AbortDict(request.get_json())
-    ids = data['ids']
-    async_result = remove_container.delay(ids, user_id=g.user.id)
-    return Response(celery_task_stream_response(async_result.task_id), mimetype='application/json')
-
-
-@bp.route('/upgrade', methods=['POST'])
-def upgrade():
-    data = AbortDict(request.get_json())
-    ids = data['ids']
-    repo = data['repo']
-    sha = data['sha']
-
-    async_result = upgrade_container_dispatch.delay(ids, repo, sha, user_id=g.user.id)
-    return Response(celery_task_stream_response(async_result.task_id), mimetype='application/json')
-
-
-@bp.errorhandler(ActionError)
-def error_handler(e):
-    return jsonify({'error': str(e)}), e.code
+    args = payload.data
+    async_result = build_image.delay(args['appname'], args['sha'])
+    for m in celery_task_stream_response(async_result.task_id):
+        logger.debug(m)
+        socket.send(str(m))

--- a/citadel/config.py
+++ b/citadel/config.py
@@ -87,8 +87,9 @@ task_queues = (
 )
 task_default_exchange = PROJECT_NAME
 task_default_routing_key = PROJECT_NAME
-task_serializer = 'pickle'
-accept_content = ['pickle', 'json']
+task_serializer = 'json'
+result_serializer = 'json'
+accept_content = ['json', 'pickle']
 beat_schedule = {
     'clean-images': {
         'task': 'citadel.tasks.clean_stuff',

--- a/citadel/ext.py
+++ b/citadel/ext.py
@@ -1,10 +1,11 @@
-# coding: utf-8
+# -*- coding: utf-8 -*-
 import mapi
 from etcd import Client
 from flask_caching import Cache
 from flask_mako import MakoTemplates
 from flask_oauthlib.client import OAuth
 from flask_session import Session
+from flask_sockets import Sockets
 from flask_sqlalchemy import SQLAlchemy
 from redis import Redis
 
@@ -21,6 +22,7 @@ def get_etcd(zone):
 db = SQLAlchemy()
 mako = MakoTemplates()
 oauth = OAuth()
+sockets = Sockets()
 rds = Redis.from_url(REDIS_URL)
 
 sso = oauth.remote_app(

--- a/citadel/libs/validation.py
+++ b/citadel/libs/validation.py
@@ -52,3 +52,8 @@ class DeploySchema(StrictSchema):
     memory = fields.Function(deserialize=parse_memory)
     count = fields.Int()
     debug = fields.Bool()
+
+
+class BuildArgsSchema(StrictSchema):
+    appname = fields.Str(required=True)
+    sha = fields.Str(required=True, validate=validate_sha)

--- a/citadel/libs/view.py
+++ b/citadel/libs/view.py
@@ -48,7 +48,7 @@ def create_page_blueprint(name, import_name, url_prefix=None):
     return bp
 
 
-def create_api_blueprint(name, import_name, url_prefix=None, jsonize=True):
+def create_api_blueprint(name, import_name, url_prefix=None, jsonize=True, handle_http_error=True):
     """
     幺蛾子, 就是因为flask写API挂路由太累了, 搞了这么个东西.
     会把url_prefix挂到/api/下.
@@ -62,14 +62,17 @@ def create_api_blueprint(name, import_name, url_prefix=None, jsonize=True):
         bp_url_prefix = os.path.join(bp_url_prefix, url_prefix)
     bp = Blueprint(name, import_name, url_prefix=bp_url_prefix)
 
-    def _error_hanlder(error):
-        return jsonify({'error': error.description}), error.code
+    if handle_http_error:
 
-    for code in ERROR_CODES:
-        bp.errorhandler(code)(_error_hanlder)
+        def _error_hanlder(error):
+            return jsonify({'error': error.description}), error.code
+
+        for code in ERROR_CODES:
+            bp.errorhandler(code)(_error_hanlder)
 
     # 如果不需要自动帮忙jsonize, 就不要
     # 可能的场景比如返回一个stream
     if jsonize:
         patch_blueprint_route(bp)
+
     return bp

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -3,3 +3,4 @@ graceful_timeout = 3600
 timeout = 1200
 max_requests = 1200
 workers = 8
+worker_class = 'flask_sockets.worker'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,5 @@ pytest
 pytest-flask
 ipython
 pdbpp
+# for commandline testing
+websocket-client

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ Flask_OAuthlib
 Flask_SQLAlchemy
 Flask-Session
 Flask-Caching
+Flask-Sockets
 redis
 smart_getenv
 SQLAlchemy

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -21,7 +21,8 @@ default_memory = parse_size('256MB', binary=True)
 
 def test_workflow():
     '''
-    build, create, remove
+    test core grpc here, no flask and celery stuff involved
+    build, create, remove, and check if everything works
     '''
     specs = make_specs()
     appname = default_appname
@@ -34,12 +35,12 @@ def test_workflow():
                                 builds=core_builds)
     core = get_core(BUILD_ZONE)
     build_image_messages = list(core.build_image(opts))
-    image = ''
+    image_tag = ''
     for m in build_image_messages:
         assert not m.error
 
-    image = m.progress
-    assert '{}:{}'.format(default_appname, default_sha) in image
+    image_tag = m.progress
+    assert '{}:{}'.format(default_appname, default_sha) in image_tag
 
     # now create container
     entrypoint_opt = pb.EntrypointOptions(name='web',
@@ -49,7 +50,7 @@ def test_workflow():
     deploy_options = pb.DeployOptions(name=default_appname,
                                       entrypoint=entrypoint_opt,
                                       podname=default_podname,
-                                      image=image,
+                                      image=image_tag,
                                       cpu_quota=default_cpu_quota,
                                       memory=default_memory,
                                       count=1,

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,12 @@
+import pytest
+
+from .prepare import core_online, default_appname, default_sha
+from citadel.tasks import build_image
+
+
+pytestmark = pytest.mark.skipif(not core_online, reason='one or more eru-core is offline, skip core-related tests')
+
+
+def test_build_image(test_db, client):
+    image_tag = build_image(default_appname, default_sha)
+    assert '{}:{}'.format(default_appname, default_sha) in image_tag


### PR DESCRIPTION
这个 PR 会作为 create_container, upgrade_container, remove_container 等返回流数据 API 的示范, 几个要点:
* 每一个 API 都是一个 `ws://` URL, 并且第一个帧作为调用参数, 用 marshmallow 进行校验和错误提示
* 测试只针对 tasks 写, API 不测, celery worker 也不测, 因为不好写