### PR TITLE
RFC: 重写容器状态(的获取和处理)

### DIFF
--- a/citadel/config.py
+++ b/citadel/config.py
@@ -29,6 +29,7 @@ MAKO_TRANSLATE_EXCEPTIONS = False
 AGENT_PORT = getenv('AGENT_PORT', default=12345, type=int)
 REDIS_URL = getenv('REDIS_URL', default='redis://127.0.0.1:6379/0')
 
+CORE_DEPLOY_INFO_PATH = '/eru-core/deploy'
 DEFAULT_ZONE = 'test-zone'
 BUILD_ZONE = 'test-zone'
 ZONE_CONFIG = {

--- a/citadel/models/loadbalance.py
+++ b/citadel/models/loadbalance.py
@@ -39,7 +39,7 @@ def get_backends(backend_name, exclude_containers=()):
                                               sha=short_sha)
                   if c not in exclude_containers and
                   not c.override_status]
-    return [b for c in containers for b in c.get_backends()]
+    return [b for c in containers for b in c.publish.values()]
 
 
 @memoize
@@ -227,11 +227,9 @@ class ELBInstance(BaseModelMixin):
         return Container.get_by_container_id(self.container_id)
 
     @property
-    def ip(self):
-        if not self.container:
-            return 'Unknown'
-        ips = self.container.get_ips()
-        return ips and ips[0] or 'Unknown'
+    def address(self):
+        _, address = self.container.publish.popitem()
+        return address
 
     def is_alive(self):
         return self.container and self.container.status() == 'running'

--- a/citadel/tasks.py
+++ b/citadel/tasks.py
@@ -259,11 +259,9 @@ def deal_with_agent_etcd_change(self, key, data):
     elif healthy:
         container.mark_initialized()
         update_elb_for_containers(container)
-        logger.debug('Healthy condition: [%s, %s, %s] ADD [%s, %s] [%s]', container.appname, container.podname, container.entrypoint, container_id, container.ident, ','.join(container.get_backends()))
     else:
         update_elb_for_containers(container, UpdateELBAction.REMOVE)
         if container.initialized and not container.is_removing():
-            logger.debug('Sick condition: [%s, %s, %s] DEL [%s, %s] [%s]', container.appname, container.podname, container.entrypoint, container_id, container.ident, ','.join(container.get_backends()))
             msg = 'Sick container `{}`\ncitadel url: {}\nkibana log: {}'.format(
                 container,
                 url_for('app.app', name=appname, _external=True),
@@ -271,7 +269,6 @@ def deal_with_agent_etcd_change(self, key, data):
             )
         else:
             container.mark_initialized()
-            logger.debug('Initial sick condition: [%s, %s, %s] DEL [%s, %s] [%s]', container.appname, container.podname, container.entrypoint, container_id, container.ident, ','.join(container.get_backends()))
 
     notbot_sendmsg(subscribers, msg)
 

--- a/citadel/templates/loadbalance/balancer.mako
+++ b/citadel/templates/loadbalance/balancer.mako
@@ -34,12 +34,12 @@
                 data-html='true'
                 data-original-title='钻进去看看'
                 data-content="
-                <a href='http://${ elb.ip }/__erulb__/upstream' target='_blank'><span class='label label-info'>upstream</span></a>
-                <a href='http://${ elb.ip }/__erulb__/rule' target='_blank'><span class='label label-info'>rule</span></a>
+                <a href='http://${ elb.address }/__erulb__/upstream' target='_blank'><span class='label label-info'>upstream</span></a>
+                <a href='http://${ elb.address }/__erulb__/rule' target='_blank'><span class='label label-info'>rule</span></a>
                 <br> <br>
                 <pre><code style='font-size:70%;white-space:nowrap' >${ ssh_command_root }</code><br><code style='font-size:70%;white-space:nowrap' >${ ssh_command_process }</code></pre>
                 ">
-                ${ elb.ip }
+                ${ elb.address }
               </a>
             </td>
             <td><span class="label label-${'success' if elb.is_alive() else 'danger'}">${ elb.container.short_id }</span></td>

--- a/citadel/templates/loadbalance/list.mako
+++ b/citadel/templates/loadbalance/list.mako
@@ -36,7 +36,7 @@
         <div class="col-sm-10">
           <select class="form-control" name="node">
             % for n in nodes:
-              <option value="${ n.name }">${ n.name } - ${ n.ip }</option>
+              <option value="${ n.name }">${ n.name } - ${ n.address }</option>
             % endfor
           </select>
         </div>
@@ -107,7 +107,7 @@
           <td><a href="${ url_for('loadbalance.elb', name=name) }">${ name }</a></td>
           <td>
             % for b in elbs:
-              <a href="http://${ b.ip }/__erulb__/upstream" target="_blank"><span class="label label-${'success' if b.is_alive() else 'danger'}">${ b.container_id[:7] } @ ${ b.ip }</span></a>
+              <a href="http://${ b.address }/__erulb__/upstream" target="_blank"><span class="label label-${'success' if b.is_alive() else 'danger'}">${ b.container_id[:7] } @ ${ b.address }</span></a>
             % endfor
           </td>
           <td>

--- a/citadel/templates/utils.mako
+++ b/citadel/templates/utils.mako
@@ -73,9 +73,9 @@
             </a>
           </td>
           <td>
-            % if c.get_ips():
-              % for n in c.get_ips():
-                <span class="block-span">${ n }</span>
+            % if c.publish:
+              % for address in c.publish.values():
+                <span class="block-span">${ address }</span>
               % endfor
             % else:
               host / none

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -66,7 +66,7 @@ def test_combo(test_db, client):
                       data=json.dumps(data),
                       headers=json_headers)
     assert res.status_code == 200
-    combo = json.loads(res.data)
+    combo = res.json
     assert combo['cpu_quota'] == 4.5
     assert combo['memory'] == parse_size('512MB', binary=True)
     assert combo['networks'] == ['release']


### PR DESCRIPTION
* citadel web 进程不再进行任何 inspect 操作, 由 watch-etcd.service 来更新容器状态数据, 这样避免了 citadel inspect 的开销(容器数量大的话还是挺恐怖的).
* watch_etcd 仅仅是触发 celery tasks, 所以不用担心 watch-etcd.service 遇到瓶颈.
* TODO: watch-etcd.service 需要完全可靠和鲁棒.
* watch_etcd 作为 pytest fixture, 涉及到 core 的测试都需要引用这个 fixture.