### PR TITLE
RFC: use github oauth2 for user login and API authentication

### DIFF
--- a/citadel/api/app.py
+++ b/citadel/api/app.py
@@ -28,6 +28,11 @@ def _get_release(appname, sha):
     return release
 
 
+@bp.route('/')
+def list_app():
+    return App.get_all()
+
+
 @bp.route('/<appname>')
 def get_app(appname):
     return _get_app(appname)

--- a/citadel/api/user.py
+++ b/citadel/api/user.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+from flask import url_for, jsonify, g, session, request, redirect, Blueprint, abort
+
+from citadel.config import OAUTH_APP_NAME
+from citadel.ext import oauth, fetch_token, update_token
+
+
+bp = Blueprint('user', __name__, url_prefix='/user')
+
+
+@bp.route('/authorized')
+def authorized():
+    if session['state'] != request.values.get('state'):
+        abort(404, 'Incorrect oauth state')
+
+    params = request.values.to_dict()
+    token = oauth.github.fetch_access_token(url_for('user.authorized', _external=True), **params)
+    update_token(OAUTH_APP_NAME, token)
+    return redirect(url_for('user.login'))
+
+
+@bp.route('/login')
+def login():
+    if fetch_token(OAUTH_APP_NAME):
+        return jsonify(g.user.to_dict())
+    url, state = oauth.github.generate_authorize_redirect(
+        url_for('user.authorized', _external=True)
+    )
+    session['state'] = state
+    return redirect(url)
+
+
+@bp.route('/logout')
+def logout():
+    session.pop('sso', None)
+    return redirect(url_for('index.index'))

--- a/citadel/config.py
+++ b/citadel/config.py
@@ -1,22 +1,21 @@
 # -*- coding: utf-8 -*-
-from datetime import timedelta
 
 import redis
 from celery.schedules import crontab
+from datetime import timedelta
 from kombu import Queue
+from mock import MagicMock
 from smart_getenv import getenv
 
 
 DEBUG = getenv('DEBUG', default=True, type=bool)
-FAKE_USER = {
-    'id': 10056,
-    'name': 'liuyifu',
-    'real_name': 'timfeirg',
-    'email': 'test@test.com',
-    'privilege': 1,
-    'token': 'token',
-    'pubkey': '',
-}
+FAKE_USER = MagicMock(
+    id=12345,
+    name='timfeirg',
+    email='timfeirg@ricebook.com',
+    privileged=1,
+)
+FAKE_USER.name = 'timfeirg'  # ...
 
 PROJECT_NAME = LOGGER_NAME = 'citadel'
 SERVER_NAME = getenv('SERVER_NAME', default='citadel.ricebook.net')
@@ -43,11 +42,11 @@ ZONE_CONFIG = {
 SQLALCHEMY_DATABASE_URI = getenv('SQLALCHEMY_DATABASE_URI', default='mysql+pymysql://root:@localhost:3306/citadeltest')
 SQLALCHEMY_TRACK_MODIFICATIONS = getenv('SQLALCHEMY_TRACK_MODIFICATIONS', default=True, type=bool)
 
-OAUTH2_BASE_URL = getenv('OAUTH2_BASE_URL', default='https://sso.ricebook.net/oauth/api/')
-OAUTH2_ACCESS_TOKEN_URL = getenv('OAUTH2_ACCESS_TOKEN_URL', default='https://sso.ricebook.net/oauth/token')
-OAUTH2_AUTHORIZE_URL = getenv('OAUTH2_AUTHORIZE_URL', default='https://sso.ricebook.net/oauth/authorize')
-OAUTH2_CLIENT_ID = getenv('OAUTH2_CLIENT_ID', default='whatever')
-OAUTH2_CLIENT_SECRET = getenv('OAUTH2_CLIENT_SECRET', default='whatever')
+OAUTH_APP_NAME = 'github'
+GITHUB_CLIENT_KEY = 'ce5e0d16937ca68c3f53'
+GITHUB_CLIENT_SECRET = 'e3f80ef7abf3446e63063bfdb211414824c923fe'
+GITHUB_CLIENT_KWARGS = {'scope': 'user:email'}
+OAUTH_CLIENT_CACHE_TYPE = 'redis'
 
 ELB_APP_NAME = getenv('ELB_APP_NAME', default='erulb3')
 ELB_BACKEND_NAME_DELIMITER = getenv('ELB_BACKEND_NAME_DELIMITER', default='___')
@@ -111,7 +110,7 @@ SESSION_USE_SIGNER = True
 SESSION_TYPE = 'redis'
 SESSION_REDIS = redis.Redis.from_url(REDIS_URL)
 SESSION_KEY_PREFIX = '{}:session:'.format(PROJECT_NAME)
-PERMANENT_SESSION_LIFETIME = timedelta(days=2)
+PERMANENT_SESSION_LIFETIME = timedelta(days=5)
 
 # flask cache settings
 CACHE_REDIS_URL = REDIS_URL

--- a/citadel/config.py
+++ b/citadel/config.py
@@ -48,8 +48,6 @@ OAUTH2_ACCESS_TOKEN_URL = getenv('OAUTH2_ACCESS_TOKEN_URL', default='https://sso
 OAUTH2_AUTHORIZE_URL = getenv('OAUTH2_AUTHORIZE_URL', default='https://sso.ricebook.net/oauth/authorize')
 OAUTH2_CLIENT_ID = getenv('OAUTH2_CLIENT_ID', default='whatever')
 OAUTH2_CLIENT_SECRET = getenv('OAUTH2_CLIENT_SECRET', default='whatever')
-AUTH_AUTHORIZE_URL = getenv('AUTH_AUTHORIZE_URL', default='https://sso.ricebook.net/auth/profile')
-AUTH_GET_USER_URL = getenv('AUTH_GET_USER_URL', default='https://sso.ricebook.net/auth/user')
 
 ELB_APP_NAME = getenv('ELB_APP_NAME', default='erulb3')
 ELB_BACKEND_NAME_DELIMITER = getenv('ELB_BACKEND_NAME_DELIMITER', default='___')

--- a/citadel/ext.py
+++ b/citadel/ext.py
@@ -1,14 +1,17 @@
 # -*- coding: utf-8 -*-
+
+from authlib.client.apps import github
+from authlib.flask.client import OAuth
 from etcd import Client
+from flask import session
 from flask_caching import Cache
 from flask_mako import MakoTemplates
-from flask_oauthlib.client import OAuth
 from flask_session import Session
 from flask_sockets import Sockets
 from flask_sqlalchemy import SQLAlchemy
 from redis import Redis
 
-from citadel.config import ZONE_CONFIG, REDIS_URL, OAUTH2_BASE_URL, OAUTH2_CLIENT_ID, OAUTH2_CLIENT_SECRET, OAUTH2_ACCESS_TOKEN_URL, OAUTH2_AUTHORIZE_URL
+from citadel.config import ZONE_CONFIG, REDIS_URL
 from citadel.libs.utils import memoize
 
 
@@ -20,20 +23,25 @@ def get_etcd(zone):
 
 db = SQLAlchemy()
 mako = MakoTemplates()
-oauth = OAuth()
 sockets = Sockets()
 rds = Redis.from_url(REDIS_URL)
 
-sso = oauth.remote_app(
-    'sso',
-    consumer_key=OAUTH2_CLIENT_ID,
-    consumer_secret=OAUTH2_CLIENT_SECRET,
-    request_token_params={'scope': 'email'},
-    base_url=OAUTH2_BASE_URL,
-    request_token_url=None,
-    access_token_url=OAUTH2_ACCESS_TOKEN_URL,
-    authorize_url=OAUTH2_AUTHORIZE_URL,
-)
+
+def fetch_token(oauth_app_name):
+    token_session_key = '{}-token'.format(oauth_app_name.lower())
+    return session.get(token_session_key)
+
+
+def update_token(oauth_app_name, token):
+    token_session_key = '{}-token'.format(oauth_app_name.lower())
+    session[token_session_key] = token
+    # I don't think return token was necessary, but that's what the example
+    # does in the docs: https://docs.authlib.org/en/latest/client/frameworks.html#cache-database
+    return token
+
+
+oauth = OAuth(fetch_token=fetch_token, update_token=update_token)
+github.register_to(oauth)
 
 cache = Cache(config={'CACHE_TYPE': 'redis'})
 sess = Session()

--- a/citadel/models/app.py
+++ b/citadel/models/app.py
@@ -276,7 +276,7 @@ class Release(BaseModelMixin):
         return None
 
     @classmethod
-    def get_by_app(cls, name, start=0, limit=20):
+    def get_by_app(cls, name, start=0, limit=None):
         app = App.get_by_name(name)
         if not app:
             return []

--- a/citadel/models/base.py
+++ b/citadel/models/base.py
@@ -38,14 +38,14 @@ class BaseModelMixin(db.Model, Jsonized):
     mget = get_multi
 
     @classmethod
-    def get_all(cls, start=0, limit=20):
+    def get_all(cls, start=0, limit=None):
         q = cls.query.order_by(cls.id.desc())
         if not any([start, limit]):
             return q.all()
         return q[start:start + limit]
 
     def update(self, **kwargs):
-        for k, v in kwargs.iteritems():
+        for k, v in kwargs.items():
             setattr(self, k, v)
 
         db.session.add(self)

--- a/citadel/models/oplog.py
+++ b/citadel/models/oplog.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
+
 import enum
 import sqlalchemy
 from flask import g
 
 from citadel.ext import db
 from citadel.models.base import BaseModelMixin, Enum34
-from citadel.models.user import get_user
 
 
 class OPType(enum.Enum):
@@ -98,11 +98,6 @@ class OPLog(BaseModelMixin):
     @property
     def verbose_action(self):
         return self.action.name
-
-    @property
-    def user_real_name(self):
-        user = get_user(self.user_id)
-        return user and user.real_name
 
     @property
     def short_sha(self):

--- a/citadel/models/user.py
+++ b/citadel/models/user.py
@@ -1,70 +1,52 @@
 # -*- coding: utf-8 -*-
-from flask import session
 
-from citadel.config import FAKE_USER, DEBUG
-from citadel.ext import sso
-from citadel.libs.cache import cache, ONE_DAY
+from authlib.client.apps import github
+
+from citadel.config import OAUTH_APP_NAME
+from citadel.ext import db, fetch_token
+from citadel.models.base import BaseModelMixin
 
 
 def get_current_user():
-    if 'sso' in session:
-        resp = sso.get('me')
-        return User.from_dict(resp.data)
+    if fetch_token(OAUTH_APP_NAME):
+        authlib_user = github.fetch_user()
+        return User.from_authlib_user(authlib_user)
     return None
 
 
-@cache(ttl=ONE_DAY)
-def get_user(identifier):
-    if not identifier:
-        return None
-    if DEBUG:
-        return User.from_dict(FAKE_USER)
-    resp = sso.get('user/%s' % identifier)
-    return resp.data and User.from_dict(resp.data) or None
+class User(BaseModelMixin):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.CHAR(50), nullable=False)
+    email = db.Column(db.String(100), nullable=False)
+    privileged = db.Column(db.Integer, default=0)
+    data = db.Column(db.JSON)
 
-
-def get_users(start=0, limit=20, q=None):
-    if DEBUG:
-        return [User.from_dict(FAKE_USER)]
-
-    data = {'start': start, 'limit': limit}
-    if q:
-        data.update({'q': q})
-
-    resp = sso.get('users', data)
-    return [User.from_dict(d) for d in resp.data if d]
-
-
-class User:
-
-    def __init__(self, id, name, email, real_name, privilege, token='', pubkey=''):
-        self.id = id
-        self.name = name
-        self.email = email
-        self.real_name = real_name
-        self.privilege = privilege
-        self.token = token
-        self.pubkey = pubkey
+    @classmethod
+    def create(cls, id, name, email, data=None):
+        user = cls(id=id, name=name, email=email, data=data)
+        db.session.add(user)
+        db.session.commit()
+        return user
 
     def __str__(self):
-        return '{class_} {u.name}'.format(
+        return '{class_} {u.id} {u.name}'.format(
             class_=self.__class__,
             u=self,
         )
 
-    def __hash__(self):
-        return hash((self.__class__, self.id))
-
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.id == other.id
-
     @classmethod
-    def from_dict(cls, info):
-        if not info or not isinstance(info, dict):
-            return None
-        return cls(info['id'], info['name'], info['email'], info['real_name'],
-                   info['privilege'], info.get('token', ''), info.get('pubkey', ''))
+    def from_authlib_user(cls, authlib_user):
+        user = cls.query.filter_by(id=authlib_user.id).first()
+        if not user:
+            user = cls.create(authlib_user.id, authlib_user.name,
+                              authlib_user.email, authlib_user.data)
+        else:
+            user.update(name=authlib_user.name, email=authlib_user.email,
+                        data=authlib_user.data)
 
-    @classmethod
-    def get(cls, id):
-        return get_user(id)
+        return user
+
+    def elevate_privilege(self):
+        self.privileged = 1
+        db.session.add(self)
+        db.session.commit()

--- a/docs/user-docs/specs.md
+++ b/docs/user-docs/specs.md
@@ -101,7 +101,7 @@ combos:
 * `erection_timeout`: str/int, 如果你启用了平滑升级, 那么 Citadel 在进行容器升级或者换新的时候, 会先启动新的容器, 等待新的容器健康以后, 再删除老的容器, 默认会等待5m, 这个参数就是来控制等待时间的. 写数字的话, 单位为秒, 也可以写 [humanfriendly](https://humanfriendly.readthedocs.io/en/latest/#humanfriendly.parse_timespan) 的时间.
 * `freeze_node`: bool, 如果为 true, 对容器进行升级/换新操作的时候, 会在原来的 node 上启动新容器, 否则由 eru-core 决定 node 分配. 默认为 false.
 * `smooth_upgrade`: bool, 默认为 true, 也就是启用平滑升级, 有些特殊的应用不允许同一个实例有两个实例同时存活, 那么就需要禁用掉平滑升级.
-* `permitted_user`: 会被加到 citade 的权限里, 这里列出的人才可以对 app 进行操作. 列出的名字是 sso.ricebook.com 里的用户名.
+* `permitted_user`: 会被加到 citade 的权限里, 这里列出的人才可以对 app 进行操作. 列出的名字是 sso 服务提供方里的用户名.
 * `combos`: 套餐, 其实是一个自由的组合. citadel 上线的时候要选的东西太多太累了, 于是有了这么个东西. 可以直接选几号套餐然后按照套餐预先设定好的参数来部署. 是一个 key-value 结构, key 就是套餐的名字, value 就是套餐的详细参数.
 	* `cpu`: float, 要多少 CPU, 注意, eru 是超售 CPU 的, 但是依然建议用多少写多少.
 	* `memory`: 要多少内存, 支持单位写法, MB, GB, KB, mb, gb, kb 都可以, 但是你要是不写那个 b, 就要死了, m, g, k 都不是单位, 只是一个放大倍率而已, b 那才是单位啊, bytes 啊! 所以你要是因为没写那个 b 挂了... 不要怪我不宽容, 怪自己没文化去...

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Flask
-Flask_OAuthlib
+Authlib
 Flask_SQLAlchemy
 Flask-Session
 Flask-Caching

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ json_headers = {'Content-Type': 'application/json'}
 @pytest.fixture
 def app(request):
     app = create_app()
-    app.config['TESTING'] = True
+    app.config['DEBUG'] = True
 
     ctx = app.app_context()
     ctx.push()

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+
+from flask import url_for, current_app
+
+
+def test_login(test_db, client):
+    current_app.config['DEBUG'] = False
+    url = url_for('app.list_app')
+    res = client.get(url)
+    assert res.status_code == 302


### PR DESCRIPTION
用 authlib 重写了登录这块, 和之前一样的流程, 只不过是换成 github.

authlib 的文档我不确定完全看懂了, 也不知道是不是这么写的..看文档感觉就是这个意思了.. 

在未登录情况下, 访问任何一个需要登录的 citadel API, 会直接返回302到 github 进行登录和授权, 所以 citadel-web 直接 relay 这个302请求就好 @tonicbupt 